### PR TITLE
Fix multiscale VO darkening transparent windows when used with new freeIVA depth masks

### DIFF
--- a/Source/PostProcessing/Effects/MultiScaleVO.cs
+++ b/Source/PostProcessing/Effects/MultiScaleVO.cs
@@ -51,12 +51,6 @@ namespace UnityEngine.Rendering.PostProcessing
         // command buffer warning
         RenderTexture m_AmbientOnlyAO;
 
-        readonly RenderTargetIdentifier[] m_MRT =
-        {
-            BuiltinRenderTextureType.GBuffer0,    // Albedo, Occ
-            BuiltinRenderTextureType.CameraTarget // Ambient
-        };
-
         public MultiScaleVO(AmbientOcclusion settings)
         {
             m_Settings = settings;
@@ -532,7 +526,7 @@ namespace UnityEngine.Rendering.PostProcessing
             var cmd = context.command;
             cmd.BeginSample("Ambient Occlusion Composite");
             cmd.SetGlobalTexture(ShaderIDs.MSVOcclusionTexture, m_AmbientOnlyAO);
-            cmd.BlitFullscreenTriangle(BuiltinRenderTextureType.None, m_MRT, BuiltinRenderTextureType.CameraTarget, m_PropertySheet, (int)Pass.CompositionDeferred);
+            cmd.BlitFullscreenTriangle(BuiltinRenderTextureType.None, BuiltinRenderTextureType.GBuffer0, BuiltinRenderTextureType.CameraTarget, m_PropertySheet, (int)Pass.CompositionDeferred);
             cmd.EndSample("Ambient Occlusion Composite");
         }
 

--- a/Source/PostProcessing/PostProcessLayer.cs
+++ b/Source/PostProcessing/PostProcessLayer.cs
@@ -568,8 +568,8 @@ namespace UnityEngine.Rendering.PostProcessing
                 context.command = m_LegacyCmdBufferBeforeReflections;
                 ao.RenderAmbientOnly(context);
 
-                // Composite with GBuffer right before the lighting pass
-                context.command = m_LegacyCmdBufferBeforeLighting;
+                // Composite with GBuffer before reflections pass which Deferred uses for ambient
+                context.command = m_LegacyCmdBufferBeforeReflections;
                 ao.CompositeAmbientOnly(context);
             }
             else if (isAmbientOcclusionOpaque)


### PR DESCRIPTION
Fix artifacts with MSVO darkening transparent windows seen here: https://github.com/LGhassen/Deferred/issues/47

The fix is simple:
- MSVO writes to the occlusion channel AFTER deferred reads from it, move it up earlier to the event "BeforeReflections" so deferred can read what it writes
- MSVO manually darkens the emission/previous camera output on texels with depth, that's not needed in deferred, get rid of it by not binding it as second rendertarget

These fixes only affect deferred rendering. I have tested but didn't do long play sessions so please review and test