### PR TITLE
Fix version file syntax error

### DIFF
--- a/GameData/TUFX/TUFX.version
+++ b/GameData/TUFX/TUFX.version
@@ -5,6 +5,6 @@
   "CHANGE_LOG_URL": "https://github.com/KSPModStewards/TUFX/blob/main/CHANGELOG.md",
   "VERSION": "1.1.1.0",
   "KSP_VERSION_MIN": "1.12.3",
-  "KSP_VERSION_MAX": "'1.12'",
+  "KSP_VERSION_MAX": "1.12",
   "KSP_VERSION": "1.12"
 }


### PR DESCRIPTION
Hey @JonnyOThan, the latest TUFX is failing to index in CKAN because there's an extra set of single quotes inside the value of `KSP_VERSION_MAX`.

`"'1.12'"`

Looks like this happened in ea4475692255804ba72dee4995c2c952c44077f7, which suggests KSPBuildTools may be responsible. Probably worth fixing that if true.
